### PR TITLE
fix eth-api healthcheck

### DIFF
--- a/ipc/docker-compose.yml
+++ b/ipc/docker-compose.yml
@@ -83,7 +83,7 @@ services:
       test: |
         curl -s -X POST 'http://localhost:8545' -H 'Content-Type: application/json' \
           --data '{"jsonrpc":"2.0", "method":"eth_chainId", "params":[], "id":1}' \
-          | jq -e '.result != null'
+          | jq -e '.result == null'
       interval: 8s
       timeout: 10s
       retries: 20

--- a/ipc/docker-compose.yml
+++ b/ipc/docker-compose.yml
@@ -81,9 +81,8 @@ services:
       - "8545:8545"
     healthcheck:
       test: |
-        curl -s -X POST 'http://localhost:8545' -H 'Content-Type: application/json' \
-          --data '{"jsonrpc":"2.0", "method":"eth_chainId", "params":[], "id":1}' \
-          | jq -e '.result == null'
+        curl --fail -s -X POST 'http://localhost:8545' -H 'Content-Type: application/json' \
+        --data '{"jsonrpc":"2.0", "method":"eth_chainId", "params":[], "id":1}' || exit 1
       interval: 8s
       timeout: 10s
       retries: 20


### PR DESCRIPTION
docker ps
```
b1b546e40759   fluencelabs/fendermint:debug   "docker-entry.sh eth…"   28 minutes ago   Up 28 minutes (unhealthy)   8445/tcp, 26658/tcp, 0.0.0.0:8545->8545/tcp, :::8545->8545/tcp        ipc-eth-api-1
```
docker logs -f b1b546e40759
```
2024-03-19T04:22:57.190031Z  INFO fendermint/app/src/cmd/mod.rs:80: reading configuration path="/fendermint/config"
2024-03-19T04:22:57.191641Z  INFO fendermint/eth/api/src/lib.rs:67: bound Ethereum API listen_addr=0.0.0.0:8545
```
